### PR TITLE
fix: Fixed small .gitignore oversight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ dist/
 build/
 *.egg-info/
 
-.idea
-.vscode
+.idea/
+.vscode/
 .DS_store


### PR DESCRIPTION
Left out the forward slash at the end of the directory names added to the .gitignore file in the previous PR, this fixes it.