### PR TITLE
fix: Restored app home page after removing blog elements of template site.

### DIFF
--- a/clothing_store/__init__.py
+++ b/clothing_store/__init__.py
@@ -39,10 +39,10 @@ def create_app(test_config=None):
 
     app.register_blueprint(auth.bp)
 
-    # register the blog blueprint
-    from . import blog
+    # register the store blueprint
+    from . import store
 
-    app.register_blueprint(blog.bp)
+    app.register_blueprint(store.bp)
     app.add_url_rule("/", endpoint="index")
 
     return app

--- a/clothing_store/store.py
+++ b/clothing_store/store.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, flash, g, redirect, render_template, request, url_for
+from werkzeug.exceptions import abort
+
+from clothing_store.auth import login_required
+from clothing_store.db import get_db
+
+bp = Blueprint("blog", __name__)
+
+@bp.route("/")
+    def index():
+        return "<h1>It works!</h1>\
+                The app is running, but this home page is WIP. If you are testing another page, navigate to it manually via the URL."


### PR DESCRIPTION
Forgot to test my previous changes to remove the blog features of the site. This pr fixes the issue where the app was not starting because of a faulty import in the __init__.py file, and implements a very simple root page with a message confirming the app is running and that the home page is WIP while informing the developer to navigate manually to the URL of the page they are attempting to test.