### PR TITLE
Updated CSS for login/register pages

### DIFF
--- a/clothing_store/static/css/auth.css
+++ b/clothing_store/static/css/auth.css
@@ -1,57 +1,37 @@
-.post > header {
-  display: flex;
-  align-items: flex-end;
-  font-size: 0.85em;
+.content {
+    margin: auto;
+    width: 330px;
 }
 
-.post > header > div:first-of-type {
-  flex: auto;
-}
-
-.post > header h1 {
-  font-size: 1.5em;
-  margin-bottom: 0;
-}
-
-.post .about {
-  color: slategray;
-  font-style: italic;
-}
-
-.post .body {
-  white-space: pre-line;
-}
-
-.content:last-child {
-  margin-bottom: 0;
+.content h1 {
+    text-align: center;
 }
 
 .content form {
-  margin: 1em 0;
-  display: flex;
-  flex-direction: column;
+    margin: 1em 0;
+    display: flex;
+    flex-direction: column;
 }
 
 .content label {
-  font-weight: bold;
-  margin-bottom: 0.5em;
+    margin-bottom: 0.5em;
 }
 
-.content input,
-.content textarea {
-  margin-bottom: 1em;
-}
-
-.content textarea {
-  min-height: 12em;
-  resize: vertical;
+.content input {
+    margin-bottom: 1em;
+    border-radius: 0;
+    border: 1px solid black;
 }
 
 input.danger {
-  color: #cc2f2e;
+    color: #cc2f2e;
 }
 
 input[type="submit"] {
-  align-self: start;
-  min-width: 10em;
+    border: 0;
+    color: white;
+    background-color: black;
+    align-self: start;
+    min-width: 7em;
+    min-height: 2em;
 }

--- a/clothing_store/static/css/base.css
+++ b/clothing_store/static/css/base.css
@@ -1,11 +1,13 @@
 html {
   font-family: sans-serif;
   background: #eee;
+  height: 100%;
 }
 
 body {
   margin: 0 auto;
   background: white;
+  height: 100%;
 }
 
 h1 {

--- a/clothing_store/static/css/home.css
+++ b/clothing_store/static/css/home.css
@@ -1,15 +1,3 @@
-html {
-  font-family: sans-serif;
-  background: #eee;
-  height: 100%;
-}
-
-body {
-  margin: 0 auto;
-  background: white;
-  height: 100%;
-}
-
 #home_page_section {
     background-image: url('../images/home-page-background.png');
     display: flex;

--- a/clothing_store/templates/auth/login.html
+++ b/clothing_store/templates/auth/login.html
@@ -4,16 +4,13 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 {% endblock %}
 
-{% block header %}
-  <h1>{% block title %}Log In{% endblock %}</h1>
-{% endblock %}
-
 {% block content %}
+  <h1>{% block title %}Log In{% endblock %}</h1>
   <form method="post">
-    <label for="login_username_textinput">Username</label>
-    <input name="username" id="login_username_textinput" required>
-    <label for="login_password_textinput">Password</label>
-    <input type="password" name="password" id="login_password_textinput" required>
-    <input type="submit" id="login_submit_button" value="Log In">
+      <label for="login_username_textinput">Username</label>
+      <input name="username" id="login_username_textinput" required>
+      <label for="login_password_textinput">Password</label>
+      <input type="password" name="password" id="login_password_textinput" required>
+      <input type="submit" id="login_submit_button" value="Log In">
   </form>
 {% endblock %}

--- a/clothing_store/templates/auth/register.html
+++ b/clothing_store/templates/auth/register.html
@@ -4,16 +4,13 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 {% endblock %}
 
-{% block header %}
-  <h1>{% block title %}Register{% endblock %}</h1>
-{% endblock %}
-
 {% block content %}
+  <h1>{% block title %}Register{% endblock %}</h1>
   <form method="post">
-    <label for="register_username_textinput">Username</label>
-    <input name="username" id="register_username_textinput" required>
-    <label for="register_password_textinput">Password</label>
-    <input type="password" name="password" id="register_password_textinput" required>
-    <input type="submit" id="register_submit_button" value="Register">
+      <label for="register_username_textinput">Username</label>
+      <input name="username" id="register_username_textinput" required>
+      <label for="register_password_textinput">Password</label>
+      <input type="password" name="password" id="register_password_textinput" required>
+      <input type="submit" id="register_submit_button" value="Register">
   </form>
 {% endblock %}

--- a/clothing_store/templates/base.html
+++ b/clothing_store/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <head>
-  <title>{% block title %}{% endblock %} - Flaskr</title>
+  <title>{% block title %}{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
   {% block head %}{% endblock %}
 </head>


### PR DESCRIPTION
Includes 2 lines added to the base CSS (and removes them from the home page's CSS file) to fix the \<html\> and \<body\> elements of every page not taking up the entire height of the available viewport, which would prevent the home page image from displaying properly and would cause weird changes to the background color randomly down some pages. I don't believe this will introduce any problems, but if it does, it is easy to override on pages it doesn't play nice with.