### PR TITLE
Added 'API-Tests-Lab' repository as submodule at tests/rest_api

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/rest_api"]
+	path = tests/rest_api
+	url = https://github.com/Group-Project-Team-4/API-Tests-Lab.git


### PR DESCRIPTION
Adds the API tests repository as a submodule such that any development that takes place for that lab can be done distinctly from this web app, but without compromising the ease of using the tests in the established environment.