### PR TITLE
Added "requests" dependency to venv for API testing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 blinker==1.6.3
+certifi==2023.11.17
+charset-normalizer==3.3.2
 click==8.1.7
+-e git+ssh://git@github.com/Group-Project-Team-4/Web-App.git@000fae40eb9c15f2de2ef88d97c73190ed7fbd08#egg=clothing_store
 coverage==7.3.2
 Flask==3.0.0
+idna==3.6
 iniconfig==2.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
@@ -9,4 +13,6 @@ MarkupSafe==2.1.3
 packaging==23.2
 pluggy==1.3.0
 pytest==7.4.2
+requests==2.31.0
+urllib3==2.1.0
 Werkzeug==3.0.1


### PR DESCRIPTION
The API testing submodule needs the Python `requests` library. This adds that dependency to the requirements.txt file. Those who need the updated dependency for running the API tests should make sure to rerun `pip install -r requirements.txt`